### PR TITLE
Fix string escaping

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -30,7 +30,12 @@ func (m *mapper) mapPtrIface(iVal reflect.Value, inlineable bool) (nodeID, strin
 }
 
 func (m *mapper) mapString(stringVal reflect.Value, inlineable bool) (nodeID, string) {
-	quoted := fmt.Sprintf("\\\"%s\\\"", stringVal.String())
+	// We want the output to look like a Go quoted string literal. The first
+	// Quote achieves that. The second is to quote it for graphviz itself.
+	quoted := strconv.Quote(strconv.Quote(stringVal.String()))
+	// Lastly, quoting adds quotation-marks around the string, but it is
+	// inserted into a graphviz string literal, so we have to remove those.
+	quoted = quoted[1 : len(quoted)-1]
 	if inlineable {
 		return 0, quoted
 	}


### PR DESCRIPTION
If a string contains quote-characters, they don't get correctly
escaped, causing syntax errors in the resulting graphviz file.
This quotes the string using strconv and then removes the
quote-characters added by that.