### PR TITLE
Upgrade cupaloy to v2, enabling raw snapshots

### DIFF
--- a/.snapshots/TestBasicTypes
+++ b/.snapshots/TestBasicTypes
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   3 [label="<name> \"Hello\""];
   4 [label="<name> \"interfaceValue\""];
@@ -6,4 +6,4 @@
   1:f3 -> 3:name;
   1:f4 -> 4:name;
 }
-)
+

--- a/.snapshots/TestFib
+++ b/.snapshots/TestFib
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   6 [label="<name> fib |{<f0> index | 0} |{<f1> prev | *memmap_test.fib(nil)} |{<f2> prevprev | *memmap_test.fib(nil)}  "];
   5 [label="<name> fib |{<f0> index | 1} |<f1> prev|{<f2> prevprev | *memmap_test.fib(nil)}  "];
@@ -16,4 +16,4 @@
   1:f1 -> 2:name;
   1:f2 -> 3:name;
 }
-)
+

--- a/.snapshots/TestMap
+++ b/.snapshots/TestMap
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   3 [label="<name> structMap |{<f0> id | \"leaf2\"} |{<f1> links | map\[*memmap.structMap\]bool}  "];
   4:<5key0> -> 1:name;
@@ -8,4 +8,3 @@
   1:<2key2> -> 4:name;
   1 [label="<name> structMap |{<f0> id | \"parent\"} |{<f1> links | {{<2key0> *memmap.structMap| <2value0> true}|{<2key1> *memmap.structMap| <2value1> true}|{<2key2> *memmap.structMap| <2value2> true}}}  "];
 }
-)

--- a/.snapshots/TestPointerAliasing
+++ b/.snapshots/TestPointerAliasing
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   2 [label="<name> \"leaf\""];
   3 [label="<name> *string"];
@@ -7,4 +7,4 @@
   1:f0 -> 3:name;
   1:f1 -> 2:name;
 }
-)
+

--- a/.snapshots/TestPointerChain
+++ b/.snapshots/TestPointerChain
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   1 [label="<name> \"Hello world\""];
   2 [label="<name> *string"];
@@ -8,4 +8,4 @@
   4 [label="<name> ***string"];
   4:name -> 3:name;
 }
-)
+

--- a/.snapshots/TestSliceTree
+++ b/.snapshots/TestSliceTree
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   4 [label="<name> tree |{<f0> id | 3} |{<f1> left | *memmap_test.tree(nil)} |{<f2> right | *memmap_test.tree(nil)}  "];
   3 [label="<name> tree |{<f0> id | 1} |{<f1> left | *memmap_test.tree(nil)} |<f2> right "];
@@ -14,4 +14,4 @@
   1:<1index3> -> 4:name;
   1 [label="<name> []*memmap_test.tree |<1index0> 0|<1index1> 1|<1index2> 2|<1index3> 3 "];
 }
-)
+

--- a/.snapshots/TestTree
+++ b/.snapshots/TestTree
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   3 [label="<name> tree |{<f0> id | 3} |{<f1> left | *memmap_test.tree(nil)} |{<f2> right | *memmap_test.tree(nil)}  "];
   2 [label="<name> tree |{<f0> id | 1} |{<f1> left | *memmap_test.tree(nil)} |<f2> right "];
@@ -9,4 +9,4 @@
   1:f1 -> 2:name;
   1:f2 -> 4:name;
 }
-)
+

--- a/.snapshots/TestVariadicArguments
+++ b/.snapshots/TestVariadicArguments
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   3 [label="<name> tree |{<f0> id | 0} |{<f1> left | *memmap_test.tree(nil)} |{<f2> right | *memmap_test.tree(nil)}  "];
   2 [label="<name> tree |{<f0> id | 1} |{<f1> left | *memmap_test.tree(nil)} |<f2> right "];
@@ -11,4 +11,4 @@
   5 [label="<name> tree |{<f0> id | 4} |<f1> left|{<f2> right | *memmap_test.tree(nil)}  "];
   5:f1 -> 4:name;
 }
-)
+

--- a/.snapshots/memmap_test-TestMap
+++ b/.snapshots/memmap_test-TestMap
@@ -1,4 +1,4 @@
-(*bytes.Buffer)(digraph structs {
+digraph structs {
   node [shape=Mrecord];
   3:<4key0> -> 1:name;
   3 [label="<name> structMap |{<f0> id | \"leaf\"} |{<f1> links | {{<4key0> *memmap_test.structMap| <4value0> true}}}  "];
@@ -10,4 +10,4 @@
   1 [label="<name> structMap |{<f0> id | \"parent\"} |<f1> links "];
   1:f1 -> 2:name;
 }
-)
+

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/bradleyjkemp/cupaloy"
   packages = ["."]
-  revision = "c9f1635bda5049b93b791588013ad7a65f38b170"
-  version = "v1.2.0"
+  revision = "0d797813a76b4573317a916b0c5816dc55fff62d"
+  version = "v2.0.0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -22,6 +22,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5f208a56399cbbd809aa6903ec476c8098fa6096b4cef240b711044a121b1fd7"
+  inputs-digest = "2a6e57b33608c07af64a42dc54065bbc92add2c53112734635be4cda3e52164c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,4 +23,4 @@
 
 [[constraint]]
   name = "github.com/bradleyjkemp/cupaloy"
-  version = "1.0.0"
+  version = "2.0.0"

--- a/memmap_test.go
+++ b/memmap_test.go
@@ -31,7 +31,7 @@ func TestBasicTypes(t *testing.T) {
 	buf := &bytes.Buffer{}
 	memmap.Map(buf, b)
 	fmt.Println(buf.String())
-	cupaloy.SnapshotT(t, buf)
+	cupaloy.SnapshotT(t, buf.Bytes())
 }
 
 type tree struct {
@@ -60,7 +60,7 @@ func TestTree(t *testing.T) {
 	b := &bytes.Buffer{}
 	memmap.Map(b, root)
 	fmt.Println(b.String())
-	cupaloy.SnapshotT(t, b)
+	cupaloy.SnapshotT(t, b.Bytes())
 }
 
 func TestVariadicArguments(t *testing.T) {
@@ -93,7 +93,7 @@ func TestVariadicArguments(t *testing.T) {
 	b := &bytes.Buffer{}
 	memmap.Map(b, root1, root2)
 	fmt.Println(b.String())
-	cupaloy.SnapshotT(t, b)
+	cupaloy.SnapshotT(t, b.Bytes())
 }
 
 func TestSliceTree(t *testing.T) {
@@ -118,7 +118,7 @@ func TestSliceTree(t *testing.T) {
 	b := &bytes.Buffer{}
 	memmap.Map(b, &slice)
 	fmt.Println(b.String())
-	cupaloy.SnapshotT(t, b)
+	cupaloy.SnapshotT(t, b.Bytes())
 }
 
 type fib struct {
@@ -162,7 +162,7 @@ func TestFib(t *testing.T) {
 	b := &bytes.Buffer{}
 	memmap.Map(b, f5)
 	fmt.Println(b.String())
-	cupaloy.SnapshotT(t, b)
+	cupaloy.SnapshotT(t, b.Bytes())
 }
 
 type structMap struct {
@@ -197,7 +197,7 @@ func TestMap(t *testing.T) {
 	fmt.Println(b.String())
 
 	// TODO: enable snapshot assertion once map keys are sorted (and so this has stable output)
-	err := cupaloy.Snapshot(b)
+	err := cupaloy.Snapshot(b.Bytes())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
@@ -212,7 +212,7 @@ func TestPointerChain(t *testing.T) {
 	b := &bytes.Buffer{}
 	memmap.Map(b, &str4)
 	fmt.Println(b.String())
-	cupaloy.SnapshotT(t, b)
+	cupaloy.SnapshotT(t, b.Bytes())
 }
 
 func TestPointerAliasing(t *testing.T) {
@@ -231,5 +231,5 @@ func TestPointerAliasing(t *testing.T) {
 	b := &bytes.Buffer{}
 	memmap.Map(b, &root)
 	fmt.Println(b.String())
-	cupaloy.SnapshotT(t, b)
+	cupaloy.SnapshotT(t, b.Bytes())
 }


### PR DESCRIPTION
This now means that the .snapshots/ folder contains valid examples which can be piped directly into graphviz.